### PR TITLE
[HRINFO-1205] sidebar cleanup

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -5,8 +5,8 @@ global-styling:
     theme:
       css/styles.css: {}
   dependencies:
-    - common_design_subtheme/hri-global-styling
     - common_design_subtheme/hri-breadcrumbs
+    - common_design_subtheme/hri-global-styling
     - common_design_subtheme/cd-read-more
 
 cd-read-more:
@@ -61,6 +61,11 @@ hri-iframe:
   css:
     component:
       components/hri-iframe/hri-iframe.css: {}
+
+hri-layout:
+  css:
+    component:
+      components/hri-layout/hri-layout.css: {}
 
 hri-pagination:
   css:

--- a/html/themes/custom/common_design_subtheme/components/hri-layout/hri-layout.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-layout/hri-layout.css
@@ -1,0 +1,33 @@
+/**
+ * HR.info custom layouts
+ */
+.hri-layout {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 2rem;
+}
+
+@media (min-width: 840px) {
+  .hri-layout {
+    flex-flow: row nowrap;
+  }
+}
+
+.hri-layout--two-col > * {
+  flex: 1 1 auto;
+}
+
+.hri-layout--two-col > .hri-layout__first {
+  order: -1;
+}
+
+.hri-layout--two-col > .hri-layout__sidebar {
+  flex: 1 1 480px;
+  padding: 1rem;
+  background-color: var(--cd-grey--light);
+}
+
+.hri-layout__sidebar .field--name-field-title {
+  margin-top: 0;
+  font-size: var(--cd-font-size--2xbase);
+}

--- a/html/themes/custom/common_design_subtheme/components/hri-layout/hri-layout.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-layout/hri-layout.css
@@ -7,7 +7,7 @@
   gap: 2rem;
 }
 
-@media (min-width: 840px) {
+@media (min-width: 880px) {
   .hri-layout {
     flex-flow: row nowrap;
   }
@@ -22,12 +22,17 @@
 }
 
 .hri-layout--two-col > .hri-layout__sidebar {
-  flex: 1 1 480px;
   padding: 1rem;
   background-color: var(--cd-grey--light);
 }
 
+@media (min-width: 880px) {
+  .hri-layout--two-col > .hri-layout__sidebar {
+    flex: 0 0 360px;
+  }
+}
+
 .hri-layout__sidebar .field--name-field-title {
   margin-top: 0;
-  font-size: var(--cd-font-size--2xbase);
+  font-size: var(--cd-font-size--large);
 }

--- a/html/themes/custom/common_design_subtheme/components/hri-powered-by/img/logo-rw.svg
+++ b/html/themes/custom/common_design_subtheme/components/hri-powered-by/img/logo-rw.svg
@@ -28,6 +28,6 @@
     <use xlink:href="#colored" width="140" height="60"/>
   </symbol>
   <!-- Actual content -->
-  <use xlink:href="#colored-with-background" x="0" y="0" width="140" height="60"/>
+  <use xlink:href="#colored" x="0" y="0" width="140" height="60"/>
   <use xlink:href="#white" x="0" y="60" width="140" height="60"/>
 </svg>

--- a/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
@@ -138,6 +138,10 @@
   padding: 0;
   font-size: var(--cd-font-size--small);
 }
+.hri-river__result .meta div {
+  display: inline;
+  white-space: nowrap;
+}
 .hri-river__result .meta dt {
   display: inline;
   margin: 0;
@@ -154,7 +158,7 @@
   margin: 0 0.5rem;
   content: "•";
 }
-.hri-river__result .meta dd:last-of-type::after {
+.hri-river__result .meta div:last-of-type dd::after {
   content: none;
 }
 

--- a/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
@@ -1,8 +1,7 @@
 /**
  * HR.info River
  */
-
-.hri-river {
+.hri-river--with-filters {
   display: flex;
   flex-flow: row wrap;
   gap: 1rem;

--- a/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-river/hri-river.css
@@ -1,43 +1,14 @@
 /**
  * HR.info River
+ *
+ * The layout is controlled by hri-layout component.
+ *
+ * @see html/themes/custom/common_design_subtheme/components/hri-layout/hri-layout.css
  */
-.hri-river--with-filters {
-  display: flex;
-  flex-flow: row wrap;
-  gap: 1rem;
 
+.hri-river {
   /* in order to position our skip-links nearer to the River itself */
-  /* stylelint-disable-next-line */
   position: relative;
-}
-
-.hri-river__results {
-  flex: 1 0 100%;
-}
-
-.hri-river__facets-wrapper {
-  flex: 1 0 100%;
-
-  /* Mobile layout has facets first. */
-  order: -1;
-}
-
-/**
- * Big layout is 2-col flexbox with facets at end of reading direction.
- */
-@media (min-width: 860px) {
-  .hri-river {
-    flex-flow: row nowrap;
-  }
-
-  .hri-river__results {
-    flex: 1 0 auto;
-  }
-
-  .hri-river__facets-wrapper {
-    flex: 1 0 280px;
-    order: initial;
-  }
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/templates/group--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/group--full.html.twig
@@ -41,6 +41,8 @@
  * @ingroup themeable
  */
 #}
+{{ attach_library('common_design_subtheme/hri-layout') }}
+
 {%
   set classes = [
     'hri-operation',
@@ -58,23 +60,18 @@
   {{ title_suffix }}
 
   <div{{ content_attributes }}>
-
     {% block section %}
-      <div class="cd-layout-two-col">
-
-        <div class="cd-layout-main-content">
+      <div class="hri-layout hri-layout--two-col">
+        <div class="hri-layout__main-content">
           {{ content|without('field_sidebar_menu')}}
         </div>
 
         {% if content.field_sidebar_menu[0] is not empty %}
-          <div class="cd-layout-sidebar-first" role="complementary">
+          <div class="hri-layout__sidebar hri-layout__first" role="complementary">
             {{ content.field_sidebar_menu }}
           </div>
         {% endif %}
-
       </div>
     {% endblock %}
-
   </div>
-
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hr-paragraphs-rw-list.html.twig
@@ -30,16 +30,23 @@
         {% endif %}
         <footer>
           <dl class="meta core">
-            <dt class="format {{ row.format|clean_class }} visually-hidden">{{ 'Format'|t }}:</dt>
-            <dd class="format {{ row.format|clean_class }}">{{ row.format }}</dd>
+            <div>
+              <dt class="format {{ row.format|clean_class }} visually-hidden">{{ 'Format'|t }}:</dt>
+              <dd class="format {{ row.format|clean_class }}">{{ row.format }}</dd>
+            </div>
 
-            <dt class="source">{{ 'Source'|t }}:</dt>
-            <dd class="source">{{ row.sources }}</dd>
+            <div>
+              <dt class="source">{{ 'Source'|t }}:</dt>
+              <dd class="source">{{ row.sources }}</dd>
+            </div>
 
-            <dt class="date posted">{{ 'Posted'|t }}:</dt>
-            <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
+            <div>
+              <dt class="date posted">{{ 'Posted'|t }}:</dt>
+              <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
+            </div>
 
             {% if row.files|length > 0 %}
+            <div>
               <dt class="files">{{ 'Files'|t }}:</dt>
               <dd class="files">
                 {% for file in row.files %}
@@ -49,6 +56,7 @@
                   </a>
                 {% endfor %}
               </dd>
+            </div>
             {% endif %}
           </dl>
         </footer>

--- a/html/themes/custom/common_design_subtheme/templates/node--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/node--full.html.twig
@@ -84,6 +84,7 @@
 {{ attach_library('common_design/cd-article') }}
 {{ attach_library('common_design/cd-author') }}
 {{ attach_library('common_design/cd-typography') }}
+{{ attach_library('common_design_subtheme/hri-layout') }}
 
 {% set unochaDate = node.getCreatedTime|date('j F Y') %}
 <article{{ attributes.addClass(classes) }}>
@@ -121,23 +122,18 @@
   {% endif %}
 
   <div{{ content_attributes }}>
-
     {% block section %}
-      <div class="cd-layout-two-col">
-
-        <div class="cd-layout-main-content">
+      <div class="hri-layout hri-layout--two-col">
+        <div class="hri-layout__main-content">
           {{ content }}
         </div>
 
         {% if field_sidebar_menu is not empty %}
-          <div class="cd-layout-sidebar-first" role="complementary">
+          <div class="hri-layout__sidebar hri-layout__first" role="complementary">
             {{ field_sidebar_menu }}
           </div>
         {% endif %}
-
       </div>
     {% endblock %}
-
   </div>
-
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/rw-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-river.html.twig
@@ -1,6 +1,6 @@
 {{ attach_library('common_design_subtheme/hri-river') }}
 
-<div class="hri-river">
+<div class="hri-river hri-river--with-filters">
   <a href="#hri-river-filters" class="visually-hidden focusable skip-link">
     {{ 'Skip to filters'|t }}
   </a>

--- a/html/themes/custom/common_design_subtheme/templates/rw-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-river.html.twig
@@ -1,11 +1,12 @@
+{{ attach_library('common_design_subtheme/hri-layout') }}
 {{ attach_library('common_design_subtheme/hri-river') }}
 
-<div class="hri-river hri-river--with-filters">
+<div class="hri-river hri-layout hri-layout--two-col">
   <a href="#hri-river-filters" class="visually-hidden focusable skip-link">
     {{ 'Skip to filters'|t }}
   </a>
 
-  <div class="hri-river__results" id="hri-river-results" aria-labelledby="hri-river-results-heading">
+  <div class="hri-river__results hri-layout__main-content" id="hri-river-results" aria-labelledby="hri-river-results-heading">
     <h2 id="hri-river-results-heading" class="visually-hidden">ReliefWeb results</h2>
 
     {% for row in data %}
@@ -76,7 +77,7 @@
     {{ 'Skip to results'|t }}
   </a>
 
-  <div class="hri-river__facets-wrapper" id="hri-river-filters" aria-labelledby="hri-river-filters-heading">
+  <div class="hri-river__facets-wrapper hri-layout__sidebar hri-layout__first" id="hri-river-filters" aria-labelledby="hri-river-filters-heading">
     <h2 id="hri-river-filters-heading" class="visually-hidden">ReliefWeb filters</h2>
 
     <div class="hri-powered-by hri-powered-by--reliefweb">

--- a/html/themes/custom/common_design_subtheme/templates/rw-river.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/rw-river.html.twig
@@ -36,16 +36,23 @@
         {% endif %}
         <footer>
           <dl class="meta core">
-            <dt class="format {{ row.format|clean_class }} visually-hidden">{{ 'Format'|t }}:</dt>
-            <dd class="format {{ row.format|clean_class }}">{{ row.format }}</dd>
+            <div>
+              <dt class="format {{ row.format|clean_class }} visually-hidden">{{ 'Format'|t }}:</dt>
+              <dd class="format {{ row.format|clean_class }}">{{ row.format }}</dd>
+            </div>
 
-            <dt class="source">{{ 'Source'|t }}:</dt>
-            <dd class="source">{{ row.sources }}</dd>
+            <div>
+              <dt class="source">{{ 'Source'|t }}:</dt>
+              <dd class="source">{{ row.sources }}</dd>
+            </div>
 
-            <dt class="date posted">{{ 'Posted'|t }}:</dt>
-            <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
+            <div>
+              <dt class="date posted">{{ 'Posted'|t }}:</dt>
+              <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
+            </div>
 
             {% if row.files|length > 0 %}
+            <div>
               <dt class="files">{{ 'Files'|t }}:</dt>
               <dd class="files">
                 {% for file in row.files %}
@@ -55,6 +62,7 @@
                   </a>
                 {% endfor %}
               </dd>
+            </div>
             {% endif %}
           </dl>
         </footer>


### PR DESCRIPTION
# HRINFO-1205

Moves the sidebar to the left on the main Operation tab, and all RW Rivers with filters have also adopted the HRI Layout component instead of providing their own. This means the RW Filters are back on the initial-start for reading direction (the left for english). I did test RTL and it "just works."

Datasets will get the same treatment, but in a separate branch.