### PR TITLE
[HRINFO-1227] add HDX URL and file links to HDX River

### DIFF
--- a/html/modules/custom/hr_paragraphs/src/Controller/ParagraphController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/ParagraphController.php
@@ -370,8 +370,10 @@ class ParagraphController extends ControllerBase {
       $data[] = [
         'id' => $row['id'],
         'title' => $row['title'],
+        'url' => 'https://data.humdata.org/dataset/' . $row['name'],
         'last_modified' => strtotime($row['last_modified']),
         'source' => $row['dataset_source'],
+        'files' => $row['resources'],
       ];
     }
 

--- a/html/modules/custom/hr_paragraphs/templates/hdx-dataset.html.twig
+++ b/html/modules/custom/hr_paragraphs/templates/hdx-dataset.html.twig
@@ -15,6 +15,18 @@
 
             <dt class="date posted">{{ 'Last updated'|t }}:</dt>
             <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
+
+            {% if row.files|length > 0 %}
+              <dt class="files">{{ 'Files'|t }}:</dt>
+              <dd class="files">
+                {% for file in row.files|slice(0,1) %}
+                  <a href="{{ file.url }}" title="{{ file.name }}">{{ 'Download'|t }}</a>
+                {% endfor %}
+                {% if row.files|length > 1 %}
+                  <em>&nbsp;+ {{ row.files|length - 1 }} more</em>
+                {% endif %}
+              </dd>
+            {% endif %}
           </dl>
         </footer>
       </article>

--- a/html/themes/custom/common_design_subtheme/templates/hdx-dataset.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/hdx-dataset.html.twig
@@ -30,6 +30,23 @@
               <dt class="date posted">{{ 'Last updated'|t }}:</dt>
               <dd class="date posted">{{ row.date_changed|date("d M Y") }}</dd>
             </div>
+
+            {% if row.files|length > 0 %}
+            <div>
+              <dt class="files">{{ 'Files'|t }}:</dt>
+              <dd class="files">
+                {% for file in row.files|slice(0,1) %}
+                  <a class="cd-button cd-button--icon cd-button--small" href="{{ file.url }}" title="{{ file.name }}">
+                    <span class="visually-hidden">{{ 'Download'|t }}</span>
+                    <svg class="cd-icon cd-icon--copyurl" aria-hidden="true" focusable="false" width="16" height="16"><use xlink:href="#cd-icon--copyurl"></use></svg>
+                  </a>
+                {% endfor %}
+                {% if row.files|length > 1 %}
+                  <em>&nbsp;+ {{ row.files|length - 1 }} more</em>
+                {% endif %}
+              </dd>
+            </div>
+            {% endif %}
           </dl>
         </footer>
       </article>
@@ -52,6 +69,6 @@
       </a>
     </div>
 
-    <p><em>No filters available for this data.</em></p>
+    <p><em>{{ 'No filters available for this data.'|t }}</em></p>
   </div>{# .hri-river__facets-wrapper #}
 </div>{# .hri-river #}


### PR DESCRIPTION
# HRINFO-1227

- Never even had the URL in the render data 😆 
- We now display file links, but we only render one. It adds "+ X more" when more than one file is present.
- Strings made to be translatable.