### PR TITLE
Remove obsolete option

### DIFF
--- a/config/field.storage.paragraph.field_rss_options.yml
+++ b/config/field.storage.paragraph.field_rss_options.yml
@@ -15,9 +15,6 @@ settings:
       value: display_date
       label: 'Display date'
     -
-      value: display_description
-      label: 'Display description'
-    -
       value: display_read_more
       label: 'Display read more link'
   allowed_values_function: ''


### PR DESCRIPTION
Execute the following locally before `drush cim`

```
drush sqlq "delete from paragraph_revision__field_rss_options where field_rss_options_value = \"display_description\""
drush sqlq "delete from paragraph__field_rss_options where field_rss_options_value = \"display_description\""
```
