### PR TITLE
feat: add cache busting parameter to RW thumbnail URLs

### DIFF
--- a/html/modules/custom/hr_paragraphs/src/Controller/ReliefwebController.php
+++ b/html/modules/custom/hr_paragraphs/src/Controller/ReliefwebController.php
@@ -215,6 +215,7 @@ class ReliefwebController extends ControllerBase {
         'source.shortname',
         'country.name',
         'primary_country.name',
+        'file.id',
         'file.url',
         'file.preview.url-thumb',
         'file.description',
@@ -357,8 +358,19 @@ class ReliefwebController extends ControllerBase {
       if (isset($row['fields']['file'])) {
         $files = [];
         foreach ($row['fields']['file'] as $file) {
+          // To avoid browser serving a stale attachment preview after the
+          // attachment is replaced on reliefweb.int, we add the file.id
+          // property as parameter to the thumbnail URL. This ID (~ revision ID)
+          // changes when replacing a file while the file URL and its preview
+          // URL are preserved (permanent URLs).
+          // The file URL doesn't need this treatment because they only use
+          // a ETag based caching strategy.
+          $preview = '';
+          if (isset($file['preview']['url-thumb'])) {
+            $preview = $this->reliefwebFixUrl($file['preview']['url-thumb']) . '?' . $file['id'];
+          }
           $files[] = [
-            'preview' => isset($file['preview']['url-thumb']) ? $this->reliefwebFixUrl($file['preview']['url-thumb']) : '',
+            'preview' => $preview,
             'url' => $this->reliefwebFixUrl($file['url']),
             'filename' => $file['filename'] ?? '',
             'description' => $file['description'] ?? '',


### PR DESCRIPTION
Ref: HRINFO-1236

This adds a parameter to the RW thumbnail URLs to prevent browsers from serving stale cached images when the file is replaced upstream.

### Testing

Check that the parameter is added the thumbnail URLs in the list of RW documents.