### PR TITLE
[HRINFO-1240] add keyboard nav to FullCalendar

### DIFF
--- a/html/modules/custom/hr_paragraphs/component/events/js/fullcalendar.js
+++ b/html/modules/custom/hr_paragraphs/component/events/js/fullcalendar.js
@@ -58,6 +58,10 @@
           title: info.title
         });
       },
+      eventRender: function (event, element, view) {
+        // Add tabindex=0 to allow keyboard to focus on each event.
+        element.attr('tabindex', '0');
+      },
     });
 
     // Use the hash parameters, if they exist. Hash is of the form:
@@ -77,6 +81,5 @@
     $(document, context).trigger('fullCalendarApiCalendar.preprocess', [calendar, calendarSettings]);
 
     calendar.fullCalendar(calendarSettings);
-
   }
 })(jQuery);

--- a/html/modules/custom/hr_paragraphs/component/events/js/fullcalendar.js
+++ b/html/modules/custom/hr_paragraphs/component/events/js/fullcalendar.js
@@ -59,8 +59,35 @@
         });
       },
       eventRender: function (event, element, view) {
-        // Add tabindex=0 to allow keyboard to focus on each event.
+        // Allow keyboard to focus on each event.
         element.attr('tabindex', '0');
+
+        // When [Enter] is pressed on focused event, open the modal dialog.
+        element.keypress(function(ev){
+          // Check if the [Enter] key was pressed.
+          if (ev.keyCode == 13) {
+            // Prepare event metadata
+            var dateFormat = 'DD.MM.YYYY hh:mmA';
+            var startdate = event.start.format(dateFormat);
+            var enddate = startdate;
+
+            if (event.end != null) {
+              enddate = event.end.format(dateFormat);
+            }
+
+            // Populate the modal dialog with this event's metadata.
+            $('#modalID').html(event.id);
+            $('#modalDescription').html(event.description);
+            $('#modalLocation').html(event.location);
+            $('#modalStartDate').html(startdate);
+            $('#modalEndDate').html(enddate);
+
+            // Display the modal
+            $('#fullCalModal').dialog({
+              title: event.title,
+            });
+          }
+        })
       },
     });
 

--- a/html/themes/custom/common_design_subtheme/components/hri-fullcalendar/hri-fullcalendar.css
+++ b/html/themes/custom/common_design_subtheme/components/hri-fullcalendar/hri-fullcalendar.css
@@ -2,6 +2,14 @@
  * HR.info customizations to FullCalendar output.
  */
 
+.fc-event:focus {
+  z-index: 10;
+  text-decoration: underline;
+  color: white;
+  outline: 4px solid var(--cd-black);
+  font-weight: 700;
+}
+
 /* stylelint-disable-next-line selector-id-pattern */
 #fullCalModal br {
   display: none;


### PR DESCRIPTION
# HRINFO-1240

- Manually adds `tabindex="0"` to each event's markup as it renders to enable keyboard nav.
- Adds an event listener so that when you press <kbd>Enter</kbd> it will open the modal as well.